### PR TITLE
Resolved bug with nested flow upload

### DIFF
--- a/projects/ng-flowchart/src/lib/ng-flowchart-canvas.service.ts
+++ b/projects/ng-flowchart/src/lib/ng-flowchart-canvas.service.ts
@@ -244,6 +244,11 @@ export class NgFlowchartCanvasService {
   }
 
   private async uploadNode(node: any, parentNode?: NgFlowchartStepComponent): Promise<NgFlowchartStepComponent> {
+    if(!node){
+      // no node to upload when uploading empty nested flow
+      return;
+    }
+
     let comp = await this.createStepFromType(node.id, node.type, node.data);
     if (!parentNode) {
       this.setRoot(comp.instance);

--- a/projects/ng-flowchart/src/lib/ng-flowchart-canvas.service.ts
+++ b/projects/ng-flowchart/src/lib/ng-flowchart-canvas.service.ts
@@ -141,6 +141,10 @@ export class NgFlowchartCanvasService {
         this.setRoot(componentRef.instance);
       }
       else {
+        // if root is replaced by another step, rerender root to proper position
+        if(dropTarget.step.isRootElement() && dropTarget.position === 'ABOVE') {
+          this.renderer.renderRoot(componentRef, drag);
+        }
         this.addChildStep(componentRef, dropTarget);
       }
 

--- a/projects/ng-flowchart/src/lib/ng-flowchart-canvas.service.ts
+++ b/projects/ng-flowchart/src/lib/ng-flowchart-canvas.service.ts
@@ -141,10 +141,6 @@ export class NgFlowchartCanvasService {
         this.setRoot(componentRef.instance);
       }
       else {
-        // if root is replaced by another step, rerender root to proper position
-        if(dropTarget.step.isRootElement() && dropTarget.position === 'ABOVE') {
-          this.renderer.renderRoot(componentRef, drag);
-        }
         this.addChildStep(componentRef, dropTarget);
       }
 

--- a/projects/workspace/src/app/app.component.ts
+++ b/projects/workspace/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { NgFlowchart } from 'projects/ng-flowchart/src/lib/model/flow.model';
 import { NgFlowchartStepRegistry } from 'projects/ng-flowchart/src/lib/ng-flowchart-step-registry.service';
 import { NgFlowchartCanvasDirective } from 'projects/ng-flowchart/src/public-api';
 import { CustomStepComponent } from './custom-step/custom-step.component';
+import { RouteStepComponent } from './custom-step/route-step/route-step.component';
 import { FormStepComponent, MyForm } from './form-step/form-step.component';
 import { NestedFlowComponent } from './nested-flow/nested-flow.component';
 
@@ -92,6 +93,7 @@ export class AppComponent {
     this.stepRegistry.registerStep('router', CustomStepComponent);
     this.stepRegistry.registerStep('nested-flow', NestedFlowComponent);
     this.stepRegistry.registerStep('form-step', FormStepComponent);
+    this.stepRegistry.registerStep('route-step', RouteStepComponent);
   }
 
   onDropError(error: NgFlowchart.DropError) {


### PR DESCRIPTION
Resolved bug with nested flow when uploading json with an empty nested flow with no root node.
Change makes it so no node is processed if it doesn't exist.

I assumed the nested flow tries to uploadNode() on it's root node, but because it doesn't exist it breaks.