### PR TITLE
Fixes to adjustDimensions that auto size correctly

### DIFF
--- a/projects/ng-flowchart/src/lib/ng-flowchart-step/ng-flowchart-step.component.ts
+++ b/projects/ng-flowchart/src/lib/ng-flowchart-step/ng-flowchart-step.component.ts
@@ -343,8 +343,8 @@ export class NgFlowchartStepComponent<T = any> {
       return;
     }
 
-    let adjustedX = pos[0] - (offsetCenter ? this.nativeElement.offsetWidth / 2 : 0);
-    let adjustedY = pos[1] - (offsetCenter ? this.nativeElement.offsetHeight / 2 : 0);
+    let adjustedX = Math.max(pos[0] - (offsetCenter ? this.nativeElement.offsetWidth / 2 : 0), 0);
+    let adjustedY = Math.max(pos[1] - (offsetCenter ? this.nativeElement.offsetHeight / 2 : 0), 0);
 
     this.nativeElement.style.left = `${adjustedX}px`;
     this.nativeElement.style.top = `${adjustedY}px`;

--- a/projects/workspace/src/app/nested-flow/nested-flow.component.html
+++ b/projects/workspace/src/app/nested-flow/nested-flow.component.html
@@ -5,6 +5,7 @@
     <span>{{ data.name }}</span>
     <div
         ngFlowchartCanvas
+        [ngFlowchartOptions]="options"
         [ngFlowchartCallbacks]="callbacks"
         class="nested-canvas-content"
     >

--- a/projects/workspace/src/app/nested-flow/nested-flow.component.ts
+++ b/projects/workspace/src/app/nested-flow/nested-flow.component.ts
@@ -20,9 +20,17 @@ export class NestedFlowComponent extends NgFlowchartStepComponent implements OnI
 
   callbacks: NgFlowchart.Callbacks = {
     afterRender: () => {
-      this.canvas.reRender()
+      this.canvas.reRender(true)
     }
   };
+
+  options: NgFlowchart.Options = {
+    stepGap: 40,
+    rootPosition: 'TOP_CENTER',
+    zoom: {
+      mode: 'DISABLED'
+    }
+  }
 
 
   constructor() {


### PR DESCRIPTION
These changes properly resize the base canvas and nested canvases based on the content by growing and shrinking as steps are added/removed if zoom is disabled.

Unhappy with new property on render function 'skipAdjustDimensions = false'. But there seems to always be minor bugs/extra renders if I did not do this. Couldn't find an easy fix/alternative.

Also don't really understand why in adjustDimensions() the  const borderGap = 100; can't be a smaller value such as 50. When I change it to something smaller, for some reason the rendering gets messed up and content scrolls. Not sure why this is a magic minimum, but maybe something to do with step gaps?