### PR TITLE
main.yml dist at root;

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,6 @@ jobs:
 
       - name: Publish
         run: npm publish --access public
-        working-directory: projects/ng-flowchart/dist
+        working-directory: dist/ng-flowchart
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Not sure how the build process was working in the first place when the ng-package.json has "dest": "../../dist/ng-flowchart".
The working directory was pointed at the library level dist folder which shouldn't exist on build. Changed it to the root dist folder to hopefully resolve CI.