### PR TITLE
feat: disable [ngFlowchartStep]

### DIFF
--- a/projects/ng-flowchart/src/lib/ng-flowchart-step.directive.ts
+++ b/projects/ng-flowchart/src/lib/ng-flowchart-step.directive.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewChecked,
   AfterViewInit,
   Directive,
   ElementRef,
@@ -11,7 +12,7 @@ import { DropDataService } from './services/dropdata.service';
 @Directive({
   selector: '[ngFlowchartStep]',
 })
-export class NgFlowchartStepDirective implements AfterViewInit {
+export class NgFlowchartStepDirective implements AfterViewInit, AfterViewChecked {
   @HostListener('dragstart', ['$event'])
   onDragStart(event: DragEvent) {
     this.data.setDragStep(this.flowStep);
@@ -25,14 +26,17 @@ export class NgFlowchartStepDirective implements AfterViewInit {
   }
 
   @Input('ngFlowchartStep')
-  flowStep: NgFlowchart.PendingStep;
+  flowStep: NgFlowchart.PendingStep | null;
 
   constructor(
     protected element: ElementRef<HTMLElement>,
     private data: DropDataService
   ) {
-    this.element.nativeElement.setAttribute('draggable', 'true');
   }
 
   ngAfterViewInit() {}
+
+  ngAfterViewChecked() {
+    this.element.nativeElement.setAttribute('draggable', this.flowStep ? 'true' : 'false');
+  }
 }

--- a/projects/workspace/src/app/app.component.html
+++ b/projects/workspace/src/app/app.component.html
@@ -14,7 +14,7 @@
         [ngFlowchartStep]="{
           template: normalStep,
           type: item.type,
-          data: item.data
+          data: item.data,
         }">
         <span>{{ item.name }}</span>
       </div>
@@ -23,6 +23,19 @@
         *ngFor="let op of customOps"
         [ngFlowchartStep]="op.step">
         <span>{{ op.paletteName }}</span>
+      </div>
+      <div
+        class="plugin-op"
+        [ngFlowchartStep]="
+          disabledStep
+            ? null
+            : {
+                template: normalStep,
+                type: items[0].type,
+                data: items[0].data,
+              }
+        ">
+        <span>{{ disabledStep ? 'Disabled' : 'Enabled' }} Step</span>
       </div>
     </section>
 
@@ -63,6 +76,13 @@
           type="checkbox"
           name="disabled"
           (change)="disabled = $any($event).target.checked" />
+      </div>
+      <div class="sub-section">
+        <label for="disabledStep">Disabled Step</label>
+        <input
+          type="checkbox"
+          name="disabledStep"
+          (change)="disabledStep = $any($event).target.checked" />
       </div>
     </section>
     <section>

--- a/projects/workspace/src/app/app.component.ts
+++ b/projects/workspace/src/app/app.component.ts
@@ -4,7 +4,7 @@ import {
   TemplateRef,
   ViewChild,
   ChangeDetectionStrategy,
-  VERSION,
+  VERSION, ChangeDetectorRef, inject,
 } from '@angular/core';
 import { NgFlowchart } from 'projects/ng-flowchart/src/lib/model/flow.model';
 import { NgFlowchartStepRegistry } from 'projects/ng-flowchart/src/lib/ng-flowchart-step-registry.service';
@@ -93,6 +93,7 @@ export class AppComponent implements AfterViewInit {
   canvas: NgFlowchartCanvasDirective;
 
   disabled = false;
+  disabledStep = false;
 
   constructor(private stepRegistry: NgFlowchartStepRegistry) {
     this.callbacks.onDropError = this.onDropError;

--- a/projects/workspace/src/app/app.component.ts
+++ b/projects/workspace/src/app/app.component.ts
@@ -4,7 +4,7 @@ import {
   TemplateRef,
   ViewChild,
   ChangeDetectionStrategy,
-  VERSION, ChangeDetectorRef, inject,
+  VERSION,
 } from '@angular/core';
 import { NgFlowchart } from 'projects/ng-flowchart/src/lib/model/flow.model';
 import { NgFlowchartStepRegistry } from 'projects/ng-flowchart/src/lib/ng-flowchart-step-registry.service';


### PR DESCRIPTION
Hello  !

So I had a personal use case where I wanted to dynamically disable some step in my palette.

For the time being, I added some checks on my node component with the `canDrop` method, but I personally think that it would be cleaner if the step isn't even draggable in the first place.

So here is my small proposal to allow this behaviour, with a working example in the workspace.

Cheers